### PR TITLE
Implemented more sensors, dynamic probe sensor creation

### DIFF
--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -72,7 +72,6 @@ void LOGICA_dTouch::loop() {
     return;
   }
 
-  ESP_LOGD(TAG, "Last sent command: %c, %d", this->last_sent_command_.command, this->last_sent_command_.data);
   switch (this->last_sent_command_.command) {
     case 'P':
       switch (this->last_sent_command_.data)

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -139,7 +139,7 @@ void LOGICA_dTouch::update() {
     case COMMAND_CONTROL_VALUES:
       current_command++;
       if (this->use_command_control_values_) {
-        const uint8_t data = 0x03;
+        const uint8_t data = 0x10;
         dtouch_send_command_('P', &data, 1);
         break;
       }

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -194,7 +194,7 @@ void LOGICA_dTouch::dump_config() {
   ESP_LOGCONFIG(TAG, "MC probes: %d", this->mc_probes_.size());
   LOG_SENSOR("  ", "EMC", this->emc_sensor_);
   ESP_LOGCONFIG(TAG, "EMC probes: %d", this->emc_probes_.size());
-  ESP_LOGCONFIG(TAG, "Sending %d command(s), one every %d ms", this->command_num_, this->update_interval_);
+  ESP_LOGCONFIG(TAG, "Sending %d command(s), one every %u ms", this->command_num_, this->update_interval_);
   this->check_uart_settings(57600, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
 
   ESP_LOGCONFIG(TAG, "Device address: %d", this->address_);

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -44,7 +44,7 @@ void LOGICA_dTouch::loop() {
     this->update();
     last_update = time;
   }
-  
+
   static uint8_t response[DTOUCH_MAX_RESPONSE_LENGTH];
 
   size_t received_length = this->dtouch_receive_packet_(response, DTOUCH_MAX_RESPONSE_LENGTH);
@@ -189,15 +189,18 @@ float LOGICA_dTouch::get_setup_priority() const { return setup_priority::DATA; }
 void LOGICA_dTouch::dump_config() {
   ESP_LOGCONFIG(TAG, "Logica dTouch:");
   LOG_SENSOR("  ", "Temperautre", this->temperature_sensor_);
-  ESP_LOGCONFIG(TAG, "Temperature probes: %d", this->temperature_probes_.size());
+  if (this->temperature_probes_.size())
+    ESP_LOGCONFIG(TAG, "    Temperature probes: %d", this->temperature_probes_.size());
   LOG_SENSOR("  ", "MC", this->mc_sensor_);
-  ESP_LOGCONFIG(TAG, "MC probes: %d", this->mc_probes_.size());
+  if (this->mc_probes_.size())
+    ESP_LOGCONFIG(TAG, "    MC probes: %d", this->mc_probes_.size());
   LOG_SENSOR("  ", "EMC", this->emc_sensor_);
-  ESP_LOGCONFIG(TAG, "EMC probes: %d", this->emc_probes_.size());
-  ESP_LOGCONFIG(TAG, "Sending %d command(s), one every %u ms", this->command_num_, this->update_interval_);
+  if (this->emc_probes_.size())
+    ESP_LOGCONFIG(TAG, "    EMC probes: %d", this->emc_probes_.size());
+  ESP_LOGCONFIG(TAG, "  Sending %d command(s), one every %u ms", this->command_num_, this->update_interval_);
   this->check_uart_settings(57600, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
 
-  ESP_LOGCONFIG(TAG, "Device address: %d", this->address_);
+  ESP_LOGCONFIG(TAG, "  Device address: %d", this->address_);
 }
 
 }  // namespace logica_dtouch

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -20,21 +20,21 @@ enum SUPPORTED_COMMMANDS {
 
 // The CRC used is CRC-16/MODBUS, sent low byte first
 uint16_t dtouch_crc(const uint8_t *bytes, size_t len, uint16_t crc) {
-    uint8_t i, j;
+  uint8_t i, j;
 
-    for (i = 0; i < len; i++) {
-        crc ^= bytes[i];
-        for (j = 0; j < 8; j++) {
-            if (crc & 0x0001) {
-                crc >>= 1;
-                crc ^= 0xA001;
-            } else {
-                crc >>= 1;
-            }
-        }
-    }
+  for (i = 0; i < len; i++) {
+      crc ^= bytes[i];
+      for (j = 0; j < 8; j++) {
+          if (crc & 0x0001) {
+              crc >>= 1;
+              crc ^= 0xA001;
+          } else {
+              crc >>= 1;
+          }
+      }
+  }
 
-    return crc;
+  return crc;
 }
 uint16_t dtouch_crc(const uint8_t byte, uint16_t crc) { return dtouch_crc(&byte, 1, crc); }
 uint16_t dtouch_crc(const uint8_t *bytes, size_t len) { return dtouch_crc(bytes, len, 0xFFFF); }

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -35,6 +35,16 @@ uint16_t dtouch_crc(const uint8_t byte) { return dtouch_crc(&byte, 1, 0xFFFF); }
 void LOGICA_dTouch::setup() {}
 
 void LOGICA_dTouch::loop() {
+  // Run the update loop
+  if (update_interval_ == UINT32_MAX)
+    return;
+  static uint32_t last_update = 0;
+  uint32_t time = millis();
+  if (time - last_update > this->update_interval_) {
+    this->update();
+    last_update = time;
+  }
+  
   static uint8_t response[DTOUCH_MAX_RESPONSE_LENGTH];
 
   size_t received_length = this->dtouch_receive_packet_(response, DTOUCH_MAX_RESPONSE_LENGTH);
@@ -59,16 +69,6 @@ void LOGICA_dTouch::loop() {
       break;
     default:
       break;
-  }
-
-  // Run the update loop
-  if (update_interval_ == UINT32_MAX)
-    return;
-  static uint32_t last_update = 0;
-  uint32_t time = millis();
-  if (time - last_update > this->update_interval_) {
-    this->update();
-    last_update = time;
   }
 }
 

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -9,6 +9,12 @@ static const size_t DTOUCH_MAX_RESPONSE_LENGTH = 128;
 static const size_t DTOUCH_STATIC_HEADER_LENGTH = 3;
 static const uint8_t DTOUCH_STATIC_HEADER[] = { 0x80, 0x00, 0x00 };
 
+enum SUPPORTED_COMMMANDS {
+  COMMAND_MC,
+  COMMAND_EMC,
+  COMMAND_TEMPERATURE
+};
+
 // The CRC used is CRC-16/MODBUS, sent low byte first
 uint16_t dtouch_crc(const uint8_t *bytes, size_t len, uint16_t crc) {
     uint8_t i, j;
@@ -73,7 +79,32 @@ void LOGICA_dTouch::loop() {
 }
 
 void LOGICA_dTouch::update() {
-  this->dtouch_send_command_('S');
+  static unsigned int current_command = 0;
+  switch (current_command) {
+    default:
+      current_command = 0;
+    case COMMAND_MC:
+      current_command++;
+      if (this->mc_sensor_ != nullptr) {
+        const uint8_t data = 0;
+        dtouch_send_command_('P', &data, 1);
+        break;
+      }
+    case COMMAND_EMC:
+      current_command++;
+      if (this->emc_sensor_ != nullptr) {
+        const uint8_t data = 2;
+        dtouch_send_command_('P', &data, 1);
+        break;
+      }
+    case COMMAND_TEMPERATURE:
+      current_command++;
+      if (this->temperature_sensor_ != nullptr) {
+        const uint8_t data = 3;
+        dtouch_send_command_('P', &data, 1);
+        break;
+      }
+  }
 }
 
 void LOGICA_dTouch::dtouch_send_command_(const uint8_t command, const uint8_t *data, const size_t data_len) {

--- a/components/logica_dtouch/logica_dtouch.cpp
+++ b/components/logica_dtouch/logica_dtouch.cpp
@@ -72,18 +72,19 @@ void LOGICA_dTouch::loop() {
     return;
   }
 
-  switch (last_sent_command_.command) {
+  ESP_LOGD(TAG, "Last sent command: %c, %d", this->last_sent_command_.command, this->last_sent_command_.data);
+  switch (this->last_sent_command_.command) {
     case 'P':
-      switch (last_sent_command_.data)
+      switch (this->last_sent_command_.data)
       {
       case 0:
-        dtouch_parse_packet_P_0_(response, received_length);
+        this->dtouch_parse_packet_P_0_(response, received_length);
         break;
       case 2:
-        dtouch_parse_packet_P_2_(response, received_length);
+        this->dtouch_parse_packet_P_2_(response, received_length);
         break;
       case 3:
-        dtouch_parse_packet_P_3_(response, received_length);
+        this->dtouch_parse_packet_P_3_(response, received_length);
         break;
       default:
         break;

--- a/components/logica_dtouch/logica_dtouch.h
+++ b/components/logica_dtouch/logica_dtouch.h
@@ -33,7 +33,9 @@ class LOGICA_dTouch : public Component, public uart::UARTDevice {
   void dtouch_send_command_(const uint8_t command, const uint8_t *data, const size_t data_len);
   size_t dtouch_receive_packet_(uint8_t *response, const size_t response_len);
 
-  void dtouch_parse_packet_S_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_0_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_2_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_3_(const uint8_t *data, const size_t len);
 
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *emc_sensor_{nullptr};

--- a/components/logica_dtouch/logica_dtouch.h
+++ b/components/logica_dtouch/logica_dtouch.h
@@ -8,14 +8,15 @@
 namespace esphome {
 namespace logica_dtouch {
 
-class LOGICA_dTouch : public PollingComponent, public uart::UARTDevice {
+class LOGICA_dTouch : public Component, public uart::UARTDevice {
  public:
   float get_setup_priority() const override;
 
   void setup() override;
   void loop() override;
-  void update() override;
   void dump_config() override;
+  // Implement our own update with custom timing
+  void update();
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_emc_sensor(sensor::Sensor *emc_sensor) { emc_sensor_ = emc_sensor; }
@@ -24,6 +25,8 @@ class LOGICA_dTouch : public PollingComponent, public uart::UARTDevice {
   void add_temperature_probe(sensor::Sensor *probe) { temperature_probes_.push_back(probe); }
   void add_emc_probe(sensor::Sensor *probe) { emc_probes_.push_back(probe); }
   void add_mc_probe(sensor::Sensor *probe) { mc_probes_.push_back(probe); }
+  void add_command() { command_num_++; }
+  void set_update_interval(uint32_t update_interval);
 
  protected:
   void dtouch_send_command_(const uint8_t command) { dtouch_send_command_(command, nullptr, 0); }
@@ -39,6 +42,8 @@ class LOGICA_dTouch : public PollingComponent, public uart::UARTDevice {
   std::vector<sensor::Sensor *> emc_probes_;
   std::vector<sensor::Sensor *> mc_probes_;
   uint8_t address_;
+  uint32_t update_interval_;
+  unsigned int command_num_ = 0;
 
   struct {
     uint8_t command = 0;

--- a/components/logica_dtouch/logica_dtouch.h
+++ b/components/logica_dtouch/logica_dtouch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
@@ -20,6 +21,9 @@ class LOGICA_dTouch : public PollingComponent, public uart::UARTDevice {
   void set_emc_sensor(sensor::Sensor *emc_sensor) { emc_sensor_ = emc_sensor; }
   void set_mc_sensor(sensor::Sensor *mc_sensor) { mc_sensor_ = mc_sensor; }
   void set_address(uint32_t address) { address_ = address; }
+  void add_temperature_probe(sensor::Sensor *probe) { temperature_probes_.push_back(probe); }
+  void add_emc_probe(sensor::Sensor *probe) { emc_probes_.push_back(probe); }
+  void add_mc_probe(sensor::Sensor *probe) { mc_probes_.push_back(probe); }
 
  protected:
   void dtouch_send_command_(const uint8_t command) { dtouch_send_command_(command, nullptr, 0); }
@@ -31,6 +35,9 @@ class LOGICA_dTouch : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *emc_sensor_{nullptr};
   sensor::Sensor *mc_sensor_{nullptr};
+  std::vector<sensor::Sensor *> temperature_probes_;
+  std::vector<sensor::Sensor *> emc_probes_;
+  std::vector<sensor::Sensor *> mc_probes_;
   uint8_t address_;
 
   struct {

--- a/components/logica_dtouch/logica_dtouch.h
+++ b/components/logica_dtouch/logica_dtouch.h
@@ -18,13 +18,26 @@ class LOGICA_dTouch : public Component, public uart::UARTDevice {
   // Implement our own update with custom timing
   void update();
 
-  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
-  void set_emc_sensor(sensor::Sensor *emc_sensor) { emc_sensor_ = emc_sensor; }
-  void set_mc_sensor(sensor::Sensor *mc_sensor) { mc_sensor_ = mc_sensor; }
-  void set_address(uint32_t address) { address_ = address; }
+  void set_temperature_sensor(sensor::Sensor *sensor) { temperature_sensor_ = sensor; }
+  void set_temperature_sensor_ideal(sensor::Sensor *sensor) { temperature_sensor_ideal_ = sensor; }
+  void set_temperature_sensor_final(sensor::Sensor *sensor) { temperature_sensor_final_ = sensor; }
   void add_temperature_probe(sensor::Sensor *probe) { temperature_probes_.push_back(probe); }
+
+  void set_emc_sensor(sensor::Sensor *sensor) { emc_sensor_ = sensor; }
+  void set_emc_sensor_ideal(sensor::Sensor *sensor) { emc_sensor_ideal_ = sensor; }
+  void set_emc_sensor_final(sensor::Sensor *sensor) { emc_sensor_final_ = sensor; }
   void add_emc_probe(sensor::Sensor *probe) { emc_probes_.push_back(probe); }
+
+  void set_mc_sensor(sensor::Sensor *sensor) { mc_sensor_ = sensor; }
+  void set_mc_sensor_final(sensor::Sensor *sensor) { mc_sensor_final_ = sensor; }
   void add_mc_probe(sensor::Sensor *probe) { mc_probes_.push_back(probe); }
+
+  void set_heating_sensor(sensor::Sensor *sensor) { heating_sensor_ = sensor; }
+  void set_fans_sensor(sensor::Sensor *sensor) {fans_sensor_ = sensor; }
+  void set_flaps_sensor(sensor::Sensor *sensor) { flaps_sensor_ = sensor; }
+  void set_sprayer_sensor(sensor::Sensor *sensor) { sprayer_sensor_ = sensor; }
+
+  void set_address(uint32_t address) { address_ = address; }
   void add_command() { command_num_++; }
   void set_update_interval(uint32_t update_interval);
 
@@ -33,19 +46,34 @@ class LOGICA_dTouch : public Component, public uart::UARTDevice {
   void dtouch_send_command_(const uint8_t command, const uint8_t *data, const size_t data_len);
   size_t dtouch_receive_packet_(uint8_t *response, const size_t response_len);
 
-  void dtouch_parse_packet_P_0_(const uint8_t *data, const size_t len);
-  void dtouch_parse_packet_P_2_(const uint8_t *data, const size_t len);
-  void dtouch_parse_packet_P_3_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_00_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_02_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_03_(const uint8_t *data, const size_t len);
+  void dtouch_parse_packet_P_10_(const uint8_t *data, const size_t len);
 
   sensor::Sensor *temperature_sensor_{nullptr};
-  sensor::Sensor *emc_sensor_{nullptr};
-  sensor::Sensor *mc_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_ideal_{nullptr};
+  sensor::Sensor *temperature_sensor_final_{nullptr};
   std::vector<sensor::Sensor *> temperature_probes_;
+
+  sensor::Sensor *emc_sensor_{nullptr};
+  sensor::Sensor *emc_sensor_ideal_{nullptr};
+  sensor::Sensor *emc_sensor_final_{nullptr};
   std::vector<sensor::Sensor *> emc_probes_;
+
+  sensor::Sensor *mc_sensor_{nullptr};
+  sensor::Sensor *mc_sensor_final_{nullptr};
   std::vector<sensor::Sensor *> mc_probes_;
+
+  sensor::Sensor *heating_sensor_{nullptr};
+  sensor::Sensor *fans_sensor_{nullptr};
+  sensor::Sensor *flaps_sensor_{nullptr};
+  sensor::Sensor *sprayer_sensor_{nullptr};
+
   uint8_t address_;
   uint32_t update_interval_;
   unsigned int command_num_ = 0;
+  bool use_command_control_values_;
 
   struct {
     uint8_t command = 0;

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -31,31 +31,25 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(cv.Schema(
-                {
-                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
-                }
-            )),
+            ).extend(cv.Schema({
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+            })),
             cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(cv.Schema(
-                {
-                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
-                }
-            )),
+            ).extend(cv.Schema({
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+            })),
             cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(cv.Schema(
-                {
-                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
-                }
-            )),
+            ).extend(cv.Schema({
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+            })),
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }
     )
@@ -77,10 +71,10 @@ async def to_code(config):
         for idx in range(0, config[CONF_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = ID(
-                    id=config[CONF_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
-                    is_declaration=config[CONF_MOISTURE_CONTENT][CONF_ID].is_declaration,
-                    is_manual=config[CONF_MOISTURE_CONTENT][CONF_ID].is_manual,
-                    type=config[CONF_MOISTURE_CONTENT][CONF_ID].type
+                id=config[CONF_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
+                is_declaration=config[CONF_MOISTURE_CONTENT][CONF_ID].is_declaration,
+                is_manual=config[CONF_MOISTURE_CONTENT][CONF_ID].is_manual,
+                type=config[CONF_MOISTURE_CONTENT][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)
@@ -92,10 +86,10 @@ async def to_code(config):
         for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = ID(
-                    id=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
-                    is_declaration=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_declaration,
-                    is_manual=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_manual,
-                    type=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
+                id=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
+                is_declaration=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_declaration,
+                is_manual=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_manual,
+                type=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)
@@ -107,10 +101,10 @@ async def to_code(config):
         for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
             custom_conf = config[CONF_TEMPERATURE].copy()
             custom_conf[CONF_ID] = ID(
-                    id=config[CONF_TEMPERATURE][CONF_ID].id + "_" + str(idx),
-                    is_declaration=config[CONF_TEMPERATURE][CONF_ID].is_declaration,
-                    is_manual=config[CONF_TEMPERATURE][CONF_ID].is_manual,
-                    type=config[CONF_TEMPERATURE][CONF_ID].type
+                id=config[CONF_TEMPERATURE][CONF_ID].id + "_" + str(idx),
+                is_declaration=config[CONF_TEMPERATURE][CONF_ID].is_declaration,
+                is_manual=config[CONF_TEMPERATURE][CONF_ID].is_manual,
+                type=config[CONF_TEMPERATURE][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -18,7 +18,7 @@ from esphome.const import (
 )
 
 CONF_MOISTURE_CONTENT = "moisture_content"
-CONF_EQUIVALENT_MOISTURE_CONTENT = "equivalent_moisture_content"
+CONF_EQUILIBRIUM_MOISTURE_CONTENT = "equilibrium_moisture_content"
 CONF_HEATING_LEVEL = "heating_level"
 CONF_FANS_LEVEL = "fans_level"
 CONF_FLAPS_LEVEL = "flaps_level"
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = (
                 cv.Required(CONF_NUM_PROBES): cv.int_range(min=0),
                 cv.Optional(CONF_FINAL_SENSOR, default=False): cv.boolean,
             })),
-            cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
+            cv.Optional(CONF_EQUILIBRIUM_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_MOISTURE,
@@ -122,32 +122,32 @@ async def to_code(config):
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_mc_sensor_final(sens))
 
-    if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
+    if CONF_EQUILIBRIUM_MOISTURE_CONTENT in config:
+        sens = await sensor.new_sensor(config[CONF_EQUILIBRIUM_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
         cg.add(var.add_command())
         
-        for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
-            custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
+        for idx in range(0, config[CONF_EQUILIBRIUM_MOISTURE_CONTENT][CONF_NUM_PROBES]):
+            custom_conf = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_probe_" + str(idx+1)
-            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_probe_" + str(idx+1)
+            custom_conf["name"] = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT]["name"] + "_probe_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.add_emc_probe(sens))
         
-        if config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_IDEAL_SENSOR]:
-            custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
+        if config[CONF_EQUILIBRIUM_MOISTURE_CONTENT][CONF_IDEAL_SENSOR]:
+            custom_conf = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_ideal"
-            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_ideal"
+            custom_conf["name"] = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT]["name"] + "_ideal"
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_emc_sensor_ideal(sens))
         
-        if config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_FINAL_SENSOR]:
-            custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
+        if config[CONF_EQUILIBRIUM_MOISTURE_CONTENT][CONF_FINAL_SENSOR]:
+            custom_conf = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_final"
-            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_final"
+            custom_conf["name"] = config[CONF_EQUILIBRIUM_MOISTURE_CONTENT]["name"] + "_final"
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_emc_sensor_final(sens))
 
@@ -199,8 +199,8 @@ async def to_code(config):
         config[CONF_TEMPERATURE][CONF_IDEAL_SENSOR] or
         config[CONF_TEMPERATURE][CONF_FINAL_SENSOR] or
         config[CONF_MOISTURE_CONTENT][CONF_FINAL_SENSOR] or
-        config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_IDEAL_SENSOR] or
-        config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_FINAL_SENSOR] or
+        config[CONF_EQUILIBRIUM_MOISTURE_CONTENT][CONF_IDEAL_SENSOR] or
+        config[CONF_EQUILIBRIUM_MOISTURE_CONTENT][CONF_FINAL_SENSOR] or
         CONF_HEATING_LEVEL in config or
         CONF_FANS_LEVEL in config or
         CONF_FLAPS_LEVEL in config or

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -1,6 +1,5 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.core import ID
 from esphome.components import uart, sensor
 from esphome.const import (
     CONF_ID,
@@ -70,12 +69,8 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
         for idx in range(0, config[CONF_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_MOISTURE_CONTENT].copy()
-            custom_conf[CONF_ID] = ID(
-                id=config[CONF_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
-                is_declaration=config[CONF_MOISTURE_CONTENT][CONF_ID].is_declaration,
-                is_manual=config[CONF_MOISTURE_CONTENT][CONF_ID].is_manual,
-                type=config[CONF_MOISTURE_CONTENT][CONF_ID].type
-            )
+            custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
             custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_mc_sensor(sens))
@@ -85,12 +80,8 @@ async def to_code(config):
         cg.add(var.set_emc_sensor(sens))
         for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
-            custom_conf[CONF_ID] = ID(
-                id=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
-                is_declaration=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_declaration,
-                is_manual=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_manual,
-                type=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
-            )
+            custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
             custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_emc_sensor(sens))
@@ -100,12 +91,8 @@ async def to_code(config):
         cg.add(var.set_emc_sensor(sens))
         for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
             custom_conf = config[CONF_TEMPERATURE].copy()
-            custom_conf[CONF_ID] = ID(
-                id=config[CONF_TEMPERATURE][CONF_ID].id + "_" + str(idx),
-                is_declaration=config[CONF_TEMPERATURE][CONF_ID].is_declaration,
-                is_manual=config[CONF_TEMPERATURE][CONF_ID].is_manual,
-                type=config[CONF_TEMPERATURE][CONF_ID].type
-            )
+            custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
             custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_temperature_sensor(sens))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -56,6 +56,15 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
+    if CONF_MOISTURE_CONTENT in config:
+        sens = await sensor.new_sensor(config[CONF_MOISTURE_CONTENT])
+        cg.add(var.set_mc_sensor(sens))
+
+    if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
+        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
+        sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
+        cg.add(var.set_emc_sensor(sens))
+
     for idx in range(0, config["num_probes"]):
         sens = await sensor.new_sensor({
             CONF_ID: "temp" + str(idx)

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -89,7 +89,7 @@ async def to_code(config):
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
-        cg.add(var.set_emc_sensor(sens))
+        cg.add(var.set_temperature_sensor(sens))
         cg.add(var.add_command())
         for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
             custom_conf = config[CONF_TEMPERATURE].copy()

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -31,7 +31,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(cv.Schema({
-                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=0)
             })),
             cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(cv.Schema({
-                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=0)
             })),
             cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
@@ -47,7 +47,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(cv.Schema({
-                cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                cv.Required(CONF_NUM_PROBES): cv.int_range(min=0)
             })),
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -83,7 +83,6 @@ async def to_code(config):
                     type=config[CONF_MOISTURE_CONTENT][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx)
-            print(custom_conf)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_mc_sensor(sens))
 
@@ -99,7 +98,6 @@ async def to_code(config):
                     type=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx)
-            print(custom_conf)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_emc_sensor(sens))
 
@@ -115,7 +113,6 @@ async def to_code(config):
                     type=config[CONF_TEMPERATURE][CONF_ID].type
             )
             custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx)
-            print(custom_conf)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_temperature_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -58,7 +58,7 @@ async def to_code(config):
 
     for idx in range(0, config["num_probes"]):
         sens = await sensor.new_sensor({
-            "name": "temp" + str(idx)
+            CONF_ID: "temp" + str(idx)
         })
         cg.add(var.set_temperature_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.core import ID
 from esphome.components import uart, sensor
 from esphome.const import (
     CONF_ID,
@@ -61,13 +62,19 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        raise Exception(str(config[CONF_EQUIVALENT_MOISTURE_CONTENT]))
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
 
     for idx in range(0, config["num_probes"]):
         sens = await sensor.new_sensor({
-            CONF_ID: "temp" + str(idx)
+            CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type="sensor::Sensor"),
+            'name': 'id="temp" + str(idx)',
+            'disabled_by_default': False,
+            'force_update': False,
+            'unit_of_measurement': '°C',
+            'accuracy_decimals': 1,
+            'device_class': 'temperature',
+            'state_class': 'measurement'
         })
         cg.add(var.set_temperature_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_ID,
     CONF_ADDRESS,
     CONF_TEMPERATURE,
+    CONF_UPDATE_INTERVAL,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
@@ -19,7 +20,7 @@ CONF_NUM_PROBES = "num_probes"
 DEPENDENCIES = ["uart"]
 
 logica_dtouch_ns = cg.esphome_ns.namespace("logica_dtouch")
-LOGICA_dTouch = logica_dtouch_ns.class_("LOGICA_dTouch", cg.PollingComponent, uart.UARTDevice)
+LOGICA_dTouch = logica_dtouch_ns.class_("LOGICA_dTouch", cg.Component, uart.UARTDevice)
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -50,9 +51,9 @@ CONFIG_SCHEMA = (
                 cv.Required(CONF_NUM_PROBES): cv.int_range(min=0)
             })),
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
+            cv.Optional(CONF_UPDATE_INTERVAL, default="5s"): cv.update_interval,
         }
     )
-    .extend(cv.polling_component_schema("5s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 
@@ -62,38 +63,39 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    type_sensor = config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
-
     if CONF_MOISTURE_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_MOISTURE_CONTENT])
         cg.add(var.set_mc_sensor(sens))
+        cg.add(var.add_command())
         for idx in range(0, config[CONF_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
-            custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_probe_" + str(idx+1)
+            custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_probe_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.add_mc_probe(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
+        cg.add(var.add_command())
         for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
-            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_probe_" + str(idx+1)
+            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_probe_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.add_emc_probe(sens))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_emc_sensor(sens))
+        cg.add(var.add_command())
         for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
             custom_conf = config[CONF_TEMPERATURE].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
-            custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx+1)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_probe_" + str(idx+1)
+            custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_probe_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.add_temperature_probe(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -42,7 +42,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional("num_probes", default=0): cv.int,
+            cv.Optional("num_probes", default=0): cv.int_,
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }
     )

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -61,7 +61,7 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
+        raise Exception(str(config[CONF_EQUIVALENT_MOISTURE_CONTENT]))
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -15,6 +15,7 @@ from esphome.const import (
 
 CONF_MOISTURE_CONTENT = "moisture_content"
 CONF_EQUIVALENT_MOISTURE_CONTENT = "equivalent_moisture_content"
+CONF_NUM_PROBES = "num_probes"
 
 DEPENDENCIES = ["uart"]
 
@@ -25,25 +26,36 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LOGICA_dTouch),
-            # cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
-            #     unit_of_measurement=UNIT_CELSIUS,
-            #     accuracy_decimals=1,
-            #     device_class=DEVICE_CLASS_TEMPERATURE,
-            #     state_class=STATE_CLASS_MEASUREMENT,
-            # ),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(cv.Schema(
+                {
+                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                }
+            )),
             cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ),
+            ).extend(cv.Schema(
+                {
+                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                }
+            )),
             cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_MOISTURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional("num_probes", default=0): cv.int_,
+            ).extend(cv.Schema(
+                {
+                    cv.Required(CONF_NUM_PROBES): cv.int_range(min=1)
+                }
+            )),
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }
     )
@@ -62,28 +74,49 @@ async def to_code(config):
     if CONF_MOISTURE_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_MOISTURE_CONTENT])
         cg.add(var.set_mc_sensor(sens))
+        for idx in range(0, config[CONF_MOISTURE_CONTENT][CONF_NUM_PROBES]):
+            custom_conf = config[CONF_MOISTURE_CONTENT].copy()
+            custom_conf[CONF_ID] = ID(
+                    id=config[CONF_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
+                    is_declaration=config[CONF_MOISTURE_CONTENT][CONF_ID].is_declaration,
+                    is_manual=config[CONF_MOISTURE_CONTENT][CONF_ID].is_manual,
+                    type=config[CONF_MOISTURE_CONTENT][CONF_ID].type
+            )
+            custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx)
+            print(custom_conf)
+            sens = await sensor.new_sensor(custom_conf)
+            cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]))
-        print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class']))
-        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
+        for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
+            custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
+            custom_conf[CONF_ID] = ID(
+                    id=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].id + "_" + str(idx),
+                    is_declaration=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_declaration,
+                    is_manual=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].is_manual,
+                    type=config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
+            )
+            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx)
+            print(custom_conf)
+            sens = await sensor.new_sensor(custom_conf)
+            cg.add(var.set_emc_sensor(sens))
 
-    for idx in range(0, config["num_probes"]):
-        custom_conf = {
-            CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type=type_sensor),
-            'name': "temp" + str(idx),
-            'disabled_by_default': False,
-            'force_update': False,
-            'unit_of_measurement': '°C',
-            'accuracy_decimals': 1,
-            'device_class': 'temperature',
-            'state_class': config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class']
-        }
-        print(custom_conf)
-        print(type(custom_conf['state_class']))
-        sens = await sensor.new_sensor(custom_conf)
-        cg.add(var.set_temperature_sensor(sens))
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_emc_sensor(sens))
+        for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
+            custom_conf = config[CONF_TEMPERATURE].copy()
+            custom_conf[CONF_ID] = ID(
+                    id=config[CONF_TEMPERATURE][CONF_ID].id + "_" + str(idx),
+                    is_declaration=config[CONF_TEMPERATURE][CONF_ID].is_declaration,
+                    is_manual=config[CONF_TEMPERATURE][CONF_ID].is_manual,
+                    type=config[CONF_TEMPERATURE][CONF_ID].type
+            )
+            custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx)
+            print(custom_conf)
+            sens = await sensor.new_sensor(custom_conf)
+            cg.add(var.set_temperature_sensor(sens))
 
     cg.add(var.set_address(config[CONF_ADDRESS]))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -64,7 +64,7 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
+        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class'])
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -66,12 +66,12 @@ async def to_code(config):
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
         print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]))
         print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class']))
-        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class'])
+        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
 
     for idx in range(0, config["num_probes"]):
-        sens = await sensor.new_sensor({
+        custom_conf = {
             CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type=type_sensor),
             'name': "temp" + str(idx),
             'disabled_by_default': False,
@@ -79,8 +79,11 @@ async def to_code(config):
             'unit_of_measurement': '°C',
             'accuracy_decimals': 1,
             'device_class': 'temperature',
-            'state_class': 'measurement'
-        })
+            'state_class': config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class']
+        }
+        print(custom_conf)
+        print(type(custom_conf['state_class']))
+        sens = await sensor.new_sensor(custom_conf)
         cg.add(var.set_temperature_sensor(sens))
 
     cg.add(var.set_address(config[CONF_ADDRESS]))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -100,3 +100,4 @@ async def to_code(config):
             cg.add(var.add_temperature_probe(sens))
 
     cg.add(var.set_address(config[CONF_ADDRESS]))
+    cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -30,18 +30,18 @@ CONFIG_SCHEMA = (
             #     device_class=DEVICE_CLASS_TEMPERATURE,
             #     state_class=STATE_CLASS_MEASUREMENT,
             # ),
-            # cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
-            #     unit_of_measurement=UNIT_PERCENT,
-            #     accuracy_decimals=1,
-            #     device_class=DEVICE_CLASS_MOISTURE,
-            #     state_class=STATE_CLASS_MEASUREMENT,
-            # ),
-            # cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
-            #     unit_of_measurement=UNIT_PERCENT,
-            #     accuracy_decimals=1,
-            #     device_class=DEVICE_CLASS_MOISTURE,
-            #     state_class=STATE_CLASS_MEASUREMENT,
-            # ),
+            cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_MOISTURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_MOISTURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
             cv.Optional("num_probes", default=0): cv.int,
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -68,7 +68,7 @@ async def to_code(config):
     for idx in range(0, config["num_probes"]):
         sens = await sensor.new_sensor({
             CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type="sensor::Sensor"),
-            'name': 'id="temp" + str(idx)',
+            'name': "temp" + str(idx),
             'disabled_by_default': False,
             'force_update': False,
             'unit_of_measurement': '°C',

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -57,6 +57,8 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
+    type_sensor = config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_ID].type
+
     if CONF_MOISTURE_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_MOISTURE_CONTENT])
         cg.add(var.set_mc_sensor(sens))
@@ -67,7 +69,7 @@ async def to_code(config):
 
     for idx in range(0, config["num_probes"]):
         sens = await sensor.new_sensor({
-            CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type="sensor::Sensor"),
+            CONF_ID: ID(id="temp" + str(idx), is_declaration=True, is_manual=True, type=type_sensor),
             'name': "temp" + str(idx),
             'disabled_by_default': False,
             'force_update': False,

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -64,6 +64,8 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
+        print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]))
+        print(type(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class']))
         print(config[CONF_EQUIVALENT_MOISTURE_CONTENT]['state_class'])
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -70,8 +70,8 @@ async def to_code(config):
         for idx in range(0, config[CONF_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
-            custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
+            custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_mc_sensor(sens))
 
@@ -81,8 +81,8 @@ async def to_code(config):
         for idx in range(0, config[CONF_EQUIVALENT_MOISTURE_CONTENT][CONF_NUM_PROBES]):
             custom_conf = config[CONF_EQUIVALENT_MOISTURE_CONTENT].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
-            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
+            custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_emc_sensor(sens))
 
@@ -92,8 +92,8 @@ async def to_code(config):
         for idx in range(0, config[CONF_TEMPERATURE][CONF_NUM_PROBES]):
             custom_conf = config[CONF_TEMPERATURE].copy()
             custom_conf[CONF_ID] = custom_conf[CONF_ID].copy()
-            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx)
-            custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx)
+            custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
+            custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
             cg.add(var.set_temperature_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -64,6 +64,7 @@ async def to_code(config):
         cg.add(var.set_mc_sensor(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
+        print(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
         cg.add(var.set_emc_sensor(sens))
 

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -73,7 +73,7 @@ async def to_code(config):
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
             custom_conf["name"] = config[CONF_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
-            cg.add(var.set_mc_sensor(sens))
+            cg.add(var.add_mc_probe(sens))
 
     if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
         sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
@@ -84,7 +84,7 @@ async def to_code(config):
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
             custom_conf["name"] = config[CONF_EQUIVALENT_MOISTURE_CONTENT]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
-            cg.add(var.set_emc_sensor(sens))
+            cg.add(var.add_emc_probe(sens))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
@@ -95,6 +95,6 @@ async def to_code(config):
             custom_conf[CONF_ID].id = custom_conf[CONF_ID].id + "_" + str(idx+1)
             custom_conf["name"] = config[CONF_TEMPERATURE]["name"] + "_" + str(idx+1)
             sens = await sensor.new_sensor(custom_conf)
-            cg.add(var.set_temperature_sensor(sens))
+            cg.add(var.add_temperature_probe(sens))
 
     cg.add(var.set_address(config[CONF_ADDRESS]))

--- a/components/logica_dtouch/sensor.py
+++ b/components/logica_dtouch/sensor.py
@@ -24,24 +24,25 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LOGICA_dTouch),
-            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_MOISTURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_MOISTURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
+            # cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+            #     unit_of_measurement=UNIT_CELSIUS,
+            #     accuracy_decimals=1,
+            #     device_class=DEVICE_CLASS_TEMPERATURE,
+            #     state_class=STATE_CLASS_MEASUREMENT,
+            # ),
+            # cv.Optional(CONF_MOISTURE_CONTENT): sensor.sensor_schema(
+            #     unit_of_measurement=UNIT_PERCENT,
+            #     accuracy_decimals=1,
+            #     device_class=DEVICE_CLASS_MOISTURE,
+            #     state_class=STATE_CLASS_MEASUREMENT,
+            # ),
+            # cv.Optional(CONF_EQUIVALENT_MOISTURE_CONTENT): sensor.sensor_schema(
+            #     unit_of_measurement=UNIT_PERCENT,
+            #     accuracy_decimals=1,
+            #     device_class=DEVICE_CLASS_MOISTURE,
+            #     state_class=STATE_CLASS_MEASUREMENT,
+            # ),
+            cv.Optional("num_probes", default=0): cv.int,
             cv.Optional(CONF_ADDRESS, default=1): cv.int_range(min=1, max=254),
         }
     )
@@ -55,16 +56,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    for idx in range(0, config["num_probes"]):
+        sens = await sensor.new_sensor({
+            "name": "temp" + str(idx)
+        })
         cg.add(var.set_temperature_sensor(sens))
-
-    if CONF_MOISTURE_CONTENT in config:
-        sens = await sensor.new_sensor(config[CONF_MOISTURE_CONTENT])
-        cg.add(var.set_mc_sensor(sens))
-
-    if CONF_EQUIVALENT_MOISTURE_CONTENT in config:
-        sens = await sensor.new_sensor(config[CONF_EQUIVALENT_MOISTURE_CONTENT])
-        cg.add(var.set_emc_sensor(sens))
 
     cg.add(var.set_address(config[CONF_ADDRESS]))


### PR DESCRIPTION
This pull request moves from using the `S` command, which returns info that is on screen, to using the `P` command, which works the same on any screen. Different P commands return different info. Additional sensors implemented are the heating, ventilation, flaps and sprayer values. Also, for existing sensors, the option to also report individual probe values, as well as the ideal and final values was added.